### PR TITLE
Upgrade rubocop version

### DIFF
--- a/template/gem_name.gemspec.erb
+++ b/template/gem_name.gemspec.erb
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'
 
-  spec.add_development_dependency 'rubocop', '~> 1.21.0'
+  spec.add_development_dependency 'rubocop', '~> 1.22.3'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0'


### PR DESCRIPTION
`undefined method 'op_asgn_type?'` error is occured on Ruby 3.1

c.f. https://github.com/rubocop/rubocop/issues/10258#issuecomment-974615729

So I upgraded rubocop version