### PR TITLE
Add support for testing against multiple Faraday versions in CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,21 +1,22 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.1'
-        bundler-cache: true
-    - name: Run RuboCop
-      run: bundle exec rubocop
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Run RuboCop
+        run: bundle exec rubocop
 
   rspec:
     runs-on: ubuntu-latest
@@ -30,13 +31,13 @@ jobs:
           - '3.0'
           - '3.1'
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Suppress git warnings
-      run: git config --global init.defaultBranch main
-    - name: Run RSpec
-      run: bundle exec rspec
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Suppress git warnings
+        run: git config --global init.defaultBranch main
+      - name: Run RSpec
+        run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
 end
 
 group :development, :lint do
-  gem 'rubocop', '~> 1.25.1'
+  gem 'rubocop', '~> 1.30'
   gem 'rubocop-performance', '~> 1.11'
   gem 'rubocop-rspec', '~> 2.5'
 end

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -1,41 +1,38 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1
-        bundler-cache: true
-    - name: Run RuboCop
-      run: bundle exec rubocop
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+      - name: Run RuboCop
+        run: bundle exec rubocop
 
   rspec:
     runs-on: ubuntu-latest
+    env:
+      FARADAY_VERSION: ${{ matrix.faraday }}
     strategy:
       fail-fast: false
       matrix:
-        ## Due to https://github.com/actions/runner/issues/849,
-        ## we have to use quotes for '3.0'
-        ruby:
-          - '2.5'
-          - '2.6'
-          - '2.7'
-          - '3.0'
-          - '3.1'
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        faraday: [ '~> 1.0', '~> 2.0' ]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Run RSpec
-      run: bundle exec rspec
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run RSpec
+        run: bundle exec rspec

--- a/template/.rubocop.yml
+++ b/template/.rubocop.yml
@@ -11,7 +11,7 @@ inherit_mode:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
   NewCops: enable
 

--- a/template/Gemfile
+++ b/template/Gemfile
@@ -3,3 +3,11 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# This block allows you to dynamically install a different version of Faraday.
+# This is useful to test your middleware against multiple versions in the CI Matrix.
+# We suggest maintainers to support at least Faraday 1.x and 2.x, but that's up to you!
+# Set in `.github/workflows/ci.yaml`, can be safely removed if you don't need this feature.
+install_if -> { ENV.fetch('FARADAY_VERSION', nil) } do
+  gem 'faraday', ENV.fetch('FARADAY_VERSION', nil)
+end

--- a/template/gem_name.gemspec.erb
+++ b/template/gem_name.gemspec.erb
@@ -30,16 +30,16 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 2.5', '< 4'
+  spec.required_ruby_version = '>= 2.6', '< 4'
 
-  spec.add_runtime_dependency 'faraday', '~> 2.0'
+  spec.add_runtime_dependency 'faraday', '>= 1.10', '< 3'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'
 
-  spec.add_development_dependency 'rubocop', '~> 1.25.1'
+  spec.add_development_dependency 'rubocop', '~> 1.30'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0'


### PR DESCRIPTION
## Summary

Add support for testing against multiple Faraday versions in CI.
By default, generated middleware will test against Faraday 1.x and 2.x, but maintainers have the option to configure this.