### PR TITLE
template: Add Dependabot GH Actions updater

### DIFF
--- a/template/.github/workflows/dependabot.yml
+++ b/template/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
This was inspired by alexwayfer's comment about version management of Actions.

A link was offered:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

This change adds Dependabot configuration "keep GitHub Actions updated" to all repositories which use this template.

The benefit is that some small maintenance is automated.