### PR TITLE
Add fix version pinning for Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
 end
 
 group :development, :lint do
-  gem 'rubocop', '~> 1.30'
+  gem 'rubocop', '~> 1.31.0'
   gem 'rubocop-performance', '~> 1.11'
   gem 'rubocop-rspec', '~> 2.5'
 end

--- a/template/gem_name.gemspec.erb
+++ b/template/gem_name.gemspec.erb
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'
 
-  spec.add_development_dependency 'rubocop', '~> 1.30'
+  spec.add_development_dependency 'rubocop', '~> 1.31.0'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0'


### PR DESCRIPTION
This is safer considering we have `NewCops: enable` in our `rubocop.yml`.
Fixes https://github.com/lostisland/faraday-middleware-template/pull/8#discussion_r904413454