### PR TITLE
Use latest Ruby for RuboCop CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: ruby ## latest MRI
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop


### PR DESCRIPTION
https://github.com/ruby/setup-ruby#supported-version-syntax

> engine only like `truffleruby`, uses the latest stable release of that implementation