### PR TITLE
Update Ruby dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,6 @@ jobs:
         ## Due to https://github.com/actions/runner/issues/849,
         ## we have to use quotes for '3.0'
         ruby:
-          - '2.6'
-          - '2.7'
           - '3.0'
           - '3.1'
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,14 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'gem_generator', '~> 0.3.0'
+  gem 'gem_generator', '~> 0.4.0'
 
   gem 'ffaker', '~> 2.20'
   gem 'rspec', '~> 3.10'
 end
 
 group :development, :lint do
-  gem 'rubocop', '~> 1.31.0'
+  gem 'rubocop', '~> 1.39.0'
   gem 'rubocop-performance', '~> 1.11'
-  gem 'rubocop-rspec', '~> 2.5'
+  gem 'rubocop-rspec', '~> 2.15.0'
 end

--- a/template/gem_name.gemspec.erb
+++ b/template/gem_name.gemspec.erb
@@ -39,8 +39,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'
 
-  spec.add_development_dependency 'rubocop', '~> 1.31.0'
+  spec.add_development_dependency 'rubocop', '~> 1.39.0'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.15.0'
 end


### PR DESCRIPTION
In the main `Gemfile` and in the template's `.gemspec`.

---

Drop Ruby 2.6 and 2.7 from CI.
They're not more supported by `gem_generator`.

Ruby 2.6 is not supported at all officially, Ruby 2.7 security maintaince will end in April 2023.

Alternative way: setup `rbenv` in CI (GH Actions) and generate by Ruby >= 3.0, switch to older versions, run specs with them. I see this way possible, but too complicated.