### PR TITLE
Add ruby 3.2 to build matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop
@@ -30,6 +30,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
         faraday: [ '~> 1.0', '~> 2.0' ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The title says everything.

💭 Even Ruby 2.7 is EOL. I wonder if this template can stop to support 2.6 and 2.7.
ref https://www.ruby-lang.org/en/downloads/branches/ , https://github.com/lostisland/faraday-middleware-template/pull/14