### PR TITLE
Use latest RuboCop version in CI task

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: ruby ## latest MRI
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: ruby ## latest MRI
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop


### PR DESCRIPTION
Re-opening of #13 

Updating is not the point. The point is to always use the latest version.