### PR TITLE
CI: Try telling dependabot about /template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "bundler"
+    directory: "/template"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/template"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
In order to reduce manual work, this change adds `directory: /template` tasks to Dependabot, same as for `directory: /`, in the hope that when we upgrade a package, it'll be updated both places.

We have an rspec test, which runs `bundle outdated` and has a return value (based on process exit status) that is truthy.