### PR TITLE
Revert "CI: Try telling dependabot about /template (#28)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "bundler"
-    directory: "/template"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/template"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This reverts commit be9f83d8b80c400a6f38d2aca9245ebadf9092b0.

Turned out to be ineffective; our .github files are .erb files, so no go.