### PR TITLE
Update CI to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,15 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'gem_generator', '~> 0.4.0'
+  gem 'gem_generator', '~> 1.0'
 
   gem 'ffaker', '~> 2.20'
+  gem 'reline'
   gem 'rspec', '~> 3.10'
 end
 
 group :development, :lint do
-  gem 'rubocop', '~> 1.63.0'
-  gem 'rubocop-performance', '~> 1.21.0'
-  gem 'rubocop-rspec', '~> 2.29.1'
+  gem 'rubocop', '~> 1.84'
+  gem 'rubocop-performance', '~> 1.26'
+  gem 'rubocop-rspec', '~> 3.9'
 end

--- a/spec/generated_project_spec.rb
+++ b/spec/generated_project_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Generated project from template' do
       "gem_generator #{gem_name} #{__dir__}/../template --namespace=#{namespace}"
     ) do |stdin, _stdout, stderr, wait_thread|
       Thread.new do
-        stderr.each { |l| puts l } unless stderr.closed?
+        stderr.each { |l| puts l } unless stderr.closed? # rubocop:disable RSpec/Output
       end
 
       stdin.puts gem_summary
@@ -163,7 +163,7 @@ RSpec.describe 'Generated project from template' do
   describe 'outdated Ruby gems' do
     subject do
       Bundler.with_unbundled_env do
-        system 'bundle outdated'
+        system 'bundle outdated --only-explicit'
       end
     end
 

--- a/template/.rubocop.yml
+++ b/template/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec

--- a/template/Gemfile
+++ b/template/Gemfile
@@ -12,12 +12,12 @@ install_if -> { ENV.fetch('FARADAY_VERSION', nil) } do
   gem 'faraday', ENV.fetch('FARADAY_VERSION', nil)
 end
 
-gem 'bundler', '~> 2.0'
-gem 'rake', '~> 13.0'
-gem 'rspec', '~> 3.0'
+gem 'bundler', '>= 2.0'
+gem 'rake', '~> 13.3'
+gem 'rspec', '~> 3.13'
 gem 'simplecov', '~> 0.22.0'
 
-gem 'rubocop', '~> 1.63.0'
-gem 'rubocop-packaging', '~> 0.5.2'
-gem 'rubocop-performance', '~> 1.21.0'
-gem 'rubocop-rspec', '~> 2.29.1'
+gem 'rubocop', '~> 1.84'
+gem 'rubocop-packaging', '~> 0.6'
+gem 'rubocop-performance', '~> 1.26'
+gem 'rubocop-rspec', '~> 3.9'

--- a/template/gem_name.gemspec.erb
+++ b/template/gem_name.gemspec.erb
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 3.0', '< 4'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'faraday', '>= 2.9', '< 3'
 end


### PR DESCRIPTION
Add Ruby 3.4 and 4.0 to the CI matrix and update the Gemfile where needed. `gem_generator` 1.0 supports only Ruby 3.2 and above, so remove Ruby 3.0 and 3.1 from the CI matrix.

Fix the bundle outdated test so it passes. Currently, rspec depends on diff-lcs 1.x, and diff-lcs 2.0 was recently released, which causes bundle outdated to fail. Add --only-explicit as a workaround.